### PR TITLE
chore(dependabot): group dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - version-update:semver-major
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to apply more conservative update constraints on development dependencies, limiting updates to minor and patch versions only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->